### PR TITLE
RedSkyBlockAddon

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 |:--:|:--:|:--:|
 |EconomyApiAddon|`{money}`|[EconomyAPI](https://github.com/poggit-orphanage/EconomyS/tree/master/EconomyAPI)|
 |RankUpAddon|`{prison_rank}`, `{prison_next_rank_price}`|[RankUp](https://github.com/falkirks/RankUp)|
+|RedSkyBlock| `{island_name}`, `{island_members}`, `{island_banned}`, `{island_locked_status}`, `{island_size}`, `{island_rank}`, `{island_value}`|[RedSkyBlock](https://github.com/RedCraftGH/RedSkyBlock)|
 |SkyBlock|`{is_state}`, `{is_blocks}`, `{is_members}`, `{is_size}`, `{is_rank}`|[SkyBlock](https://github.com/GiantQuartz/SkyBlock)|
 |PurePerms|`{rank}`, `{prefix}`, `{suffix}`|[PurePerms](https://github.com/poggit-orphanage/PurePerms)|
 |FactionsPro|`{faction}`, `{faction_power}`|[FactionsPro](https://github.com/poggit-orphanage/FactionsPro)|

--- a/RedSkyBlockAddon.php
+++ b/RedSkyBlockAddon.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @name RedSkyBlockAddon
+ * @version 1.0.0
+ * @main JackMD\ScoreHud\Addons\RedSkyBlockAddon
+ * @depend RedSkyBlock
+ * @api 3.0.0
+ */
+
+namespace JackMD\ScoreHud\Addons {
+
+  use JackMD\ScoreHud\addon\AddonBase;
+  use RedCraftPE\RedSkyBlock\SkyBlock;
+  use pocketmine\Player;
+
+  class RedSkyBlockAddon extends AddonBase {
+
+    private $redSkyBlockAPI;
+
+    public function onEnable(): void {
+
+      $this->redSkyBlockAPI = $this->getServer()->getPluginManager()->getPlugin("RedSkyBlock");
+    }
+    public function getProcessedTags(Player $player): array {
+      return [
+        "{island_name}" => $this->redSkyBlockAPI->getIslandName($player),
+        "{island_members}" => $this->redSkyBlockAPI->getMembers($player),
+        "{island_banned}" => $this->redSkyBlockAPI->getBanned($player),
+        "{island_locked_status}" => $this->redSkyBlockAPI->getLockedStatus($player),
+        "{island_size}" => $this->redSkyBlockAPI->getSize($player),
+        "{island_rank}" => $this->redSkyBlockAPI->calcRank(strtolower($player->getName())),
+        "{island_value}" => $this->redSkyBlockAPI->getValue($player)
+      ];
+    }
+  }
+}


### PR DESCRIPTION
`{island_name}`: Displays the name of a player's island.
`{island_members}`: Displays the members of a player's island.
`{island_banned}`: Displays those banned from a player's island.
`{island_locked_status}`: Displays the current lock status of a player's island.
`{island_size}`: Displays the size of a player's island as `length x width`
`{island_rank}`: Displays the rank of a player's island.
`{island_value}`: Displays the value of a player's island--value determines rank.